### PR TITLE
Default UOM for the Weight on the delivery order is not correct.

### DIFF
--- a/addons/delivery/models/stock_picking.py
+++ b/addons/delivery/models/stock_picking.py
@@ -52,11 +52,8 @@ class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
     def _default_uom(self):
-        weight_uom_id = self.env.ref('product.product_uom_kgm', raise_if_not_found=False)
-        if not weight_uom_id:
-            uom_categ_id = self.env.ref('product.product_uom_categ_kgm').id
-            weight_uom_id = self.env['product.uom'].search([('category_id', '=', uom_categ_id), ('factor', '=', 1)], limit=1)
-        return weight_uom_id
+        uom_categ_id = self.env.ref('product.product_uom_categ_kgm').id
+        return self.env['product.uom'].search([('category_id', '=', uom_categ_id), ('factor', '=', 1)], limit=1)
 
     @api.one
     @api.depends('move_line_ids')


### PR DESCRIPTION
Current behavior before PR: 
When we set lb as the reference unit of measure for weight category, odoo shows kg as the default uom for the weight on the delivery order.

Desired behavior after PR is merged:
When we set lb as the reference unit of measure for weight category, odoo should show lb as the default uom for the weight on the delivery order.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
